### PR TITLE
Fix lambda temporary shared_ptr not used (avoid side effects)

### DIFF
--- a/src/served/net/connection.cpp
+++ b/src/served/net/connection.cpp
@@ -74,7 +74,7 @@ connection::start()
 		_read_timer.async_wait([this, self](const boost::system::error_code& error) {
 			if ( error.value() != boost::system::errc::operation_canceled )
 			{
-				_connection_manager.stop(shared_from_this());
+				_connection_manager.stop(self);
 			}
 		});
 	}
@@ -129,7 +129,7 @@ connection::do_read()
 						_write_timer.async_wait([this, self](const boost::system::error_code& error) {
 							if ( error.value() != boost::system::errc::operation_canceled )
 							{
-								_connection_manager.stop(shared_from_this());
+								_connection_manager.stop(self);
 							}
 						});
 					}
@@ -178,7 +178,7 @@ connection::do_read()
 			}
 			else if (ec != boost::asio::error::operation_aborted)
 			{
-				_connection_manager.stop(shared_from_this());
+				_connection_manager.stop(self);
 			}
 		}
 	);
@@ -209,7 +209,7 @@ connection::do_write()
 
 			if ( ec != boost::asio::error::operation_aborted )
 			{
-				_connection_manager.stop(shared_from_this());
+				_connection_manager.stop(self);
 			}
 		}
 	);


### PR DESCRIPTION
It seems I forgot one